### PR TITLE
[Feat/#7] 내정보창 ui 생성

### DIFF
--- a/Targets/D3N/Sources/Presentation/Question/Result/View/QuestionResultView.swift
+++ b/Targets/D3N/Sources/Presentation/Question/Result/View/QuestionResultView.swift
@@ -19,42 +19,55 @@ public struct QuestionResultView: View {
     
     public var body: some View {
         ScrollView {
-            VStack(spacing: 10) {
-                HStack {
-                    Text("문제")
-                        .font(.title)
-                    
-                    Spacer()
-                }
+            ZStack{
                 
+            }
+            VStack {
+//                HStack {
+//                    Text("문제")
+//                        .padding()
+//                        .frame(maxWidth: .infinity, alignment: .leading)
+//                    Spacer()
+//                }
+// 나중에 navigation bar 따로 만드려고 일단 주석으로 뺌
                 ForEach(viewModel.quizs, id: \.self) { quiz in
-                    VStack {
+                    VStack (alignment: .trailing){
                         HStack {
                             Text(quiz.question)
-                                .font(.headline)
+                                .font(.title)
+                                .fontWeight(.semibold)
                             Spacer()
-                        }
+                        }.padding(.bottom) .padding(.top)
                         
-                        VStack {
+                        VStack{
                             ForEach(Array(quiz.choiceList.enumerated()), id: \.offset) { index, choice in
                                 HStack {
                                     Text("\(index+1). \(choice)")
                                         .font(.body)
-                                        .foregroundStyle(index + 1 == quiz.answer ? Color.init(uiColor: .systemPink) : Color.init(uiColor: .label))
-                                        .fontWeight(index + 1 == quiz.answer ? .semibold : .regular)
+                                        .foregroundStyle(index + 1 == quiz.answer ? Color.init(uiColor: .systemIndigo) : Color.init(uiColor: .label))
+                                        .fontWeight(index + 1 == quiz.answer ? .bold : .regular)
+// 유저가 고른 정답 == 원래 정답이면 green, 아니면 고른 정답은 red나 pink, 원래 정답은 indigo로 표현하고 싶은데 유저 정답 테스트 데이터가 있나?
                                     Spacer()
                                 }
                             }
                         }
                     }
                 }
-                
-                Button("Root") {
-                    viewModel.send(.rootButtonTapped)
-                }
             }
             .padding()
         }
+        VStack{
+            Button{
+                viewModel.send(.rootButtonTapped)
+            } label:{
+                Text("뉴스 목록으로 돌아가기")
+                    .frame(maxWidth: .infinity)
+                    .controlSize(.large)
+                    .shadow(radius: 4, x: 0, y: 4)
+            }
+            .tint(.indigo)
+            .buttonStyle(.borderedProminent)
+        }.padding()
         .onReceive(viewModel.$popToRoot) { popToRoot in
             if popToRoot {
                 switch viewModel.parent {


### PR DESCRIPTION
## PR 요약
문제에 대한 정답 UI 수정

#### 📌 변경 사항
UI 색에 맞춰서 버튼과 글자 색 조절, 버튼 항상 화면에 띄워져 있도록 수정

##### ✅ PR check list
보기에서 정답을 표시할 때 유저가 고른 정답 == 원래 정답이면 green, 아니면 고른 정답은 red나 pink, 원래 정답은 indigo로 표현하고 싶은데 유저 정답 테스트 데이터 추가가 가능한지

뉴스로 돌아가기 버튼을 항상 화면 위에 두고 싶어서 scrollview 바깥 아래쪽에 vstack으로 넣었는데 알맞은 방법인지

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #7


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->